### PR TITLE
Use NanostackRfPhy::get_default_instance() for finding the driver

### DIFF
--- a/TEST_APPS/device/nanostack_mac_tester/README.md
+++ b/TEST_APPS/device/nanostack_mac_tester/README.md
@@ -15,9 +15,7 @@ You can use this application to test the Nanostack RF driver implementations tha
 ## Prerequisites
 
 * [Mbed CLI](https://github.com/ARMmbed/mbed-cli).
-* Three supported boards with radio shields. For example, FRDM-K64F with FRDM-CR20A radio shield.
-    * https://os.mbed.com/platforms/FRDM-K64F/
-    * https://os.mbed.com/components/FRDM-CR20A/
+* Mbed OS target board with build in radio, OR RF shield with Mbed OS driver
 
 ## Setting up the application
 
@@ -37,24 +35,15 @@ To add your RF driver:
 mbed add https://www.github.com/me/my-rf-driver.git
 ```
 
-Set `radio-type` in `mbed_app.json` to `OTHER`:
+When using RF shield, you need to configure it to be a default RF driver and instruct Mbed OS that RF driver is present. For example, configuring Atmel RF driver to provide default driver:
 
 ```
-"config":{
-    "radio-type":{
-        "value": "ATMEL" --> "value": "OTHER"
-    }
-}
+    "target_overrides": {
+        "*": {
+            "target.device_has_add": ["802_15_4_RF_PHY"],
+            "atmel-rf.provide-default": true
 ```
 
-Replace the placeholders in `main.cpp` with your RF driver header file and interface definition:
-
-```
-#elif MBED_CONF_APP_RADIO_TYPE == OTHER
-#include "YOUR_DRIVER_HEADER.h"
-YourDriverInterface rf_phy(...);
-#endif
-```
 
 ### Compile your binary
 

--- a/TEST_APPS/device/nanostack_mac_tester/main.cpp
+++ b/TEST_APPS/device/nanostack_mac_tester/main.cpp
@@ -33,17 +33,10 @@
 #define TRACE_GROUP "Main"
 #include "mbed-trace/mbed_trace.h"
 
-#if MBED_CONF_APP_RADIO_TYPE == ATMEL
-#include "NanostackRfPhyAtmel.h"
-NanostackRfPhyAtmel rf_phy(ATMEL_SPI_MOSI, ATMEL_SPI_MISO, ATMEL_SPI_SCLK, ATMEL_SPI_CS,
-                           ATMEL_SPI_RST, ATMEL_SPI_SLP, ATMEL_SPI_IRQ, ATMEL_I2C_SDA, ATMEL_I2C_SCL);
-#elif MBED_CONF_APP_RADIO_TYPE == MCR20
-#include "NanostackRfPhyMcr20a.h"
-NanostackRfPhyMcr20a rf_phy(MCR20A_SPI_MOSI, MCR20A_SPI_MISO, MCR20A_SPI_SCLK, MCR20A_SPI_CS, MCR20A_SPI_RST, MCR20A_SPI_IRQ);
-#elif MBED_CONF_APP_RADIO_TYPE == OTHER
-#include "YOUR_DRIVER_HEADER.h"
-YourDriverInterface rf_phy(...);
-#endif //MBED_CONF_APP_RADIO_TYPE
+#if !DEVICE_802_15_4_PHY
+#error [NOT_SUPPORTED] No 802.15.4 RF driver found for this target
+#endif
+
 
 extern mac_api_s *mac_interface;
 RawSerial pc(USBTX, USBRX);
@@ -94,6 +87,7 @@ static void handle_rx_data(void)
 
 static int mac_prepare(void)
 {
+    NanostackRfPhy rf_phy = NanostackRfPhy::get_default_instance();
     int8_t rf_driver_id = rf_phy.rf_register();
     uint8_t rf_eui64[8];
 

--- a/TEST_APPS/device/nanostack_mac_tester/mbed_app.json
+++ b/TEST_APPS/device/nanostack_mac_tester/mbed_app.json
@@ -1,14 +1,8 @@
 {
-    "config": {
-        "radio-type":{
-            "help": "options are ATMEL, MCR20, OTHER",
-            "value": "ATMEL"
-        }
-    },
     "macros": ["YOTTA_CFG_MBED_TRACE_LINE_LENGTH=200", "OS_TASKCNT=4", "OS_IDLESTKSIZE=32"],
     "target_overrides": {
         "*": {
-            "target.features_add": ["NANOSTACK", "LOWPAN_HOST", "COMMON_PAL"],
+            "nanostack.configuration": "lowpan_host",
             "platform.stdio-convert-newlines": true,
             "platform.stdio-baud-rate": 115200,
             "mbed-mesh-api.heap-size": 6000,


### PR DESCRIPTION
### Description

Use NanostackRfPhy::get_default_instance() for finding the driver

@JuhPuur  please test & review.
